### PR TITLE
Support React v17

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,6 +1,8 @@
 module.exports = {
-  projects: ['default', 'v0.14.0', 'v15.0.0', 'v16.0.0', 'v16.4.0', 'v16.13.0'].map((version) => ({
-    displayName: version,
-    testMatch: [`<rootDir>/tests/${version}/*.spec.js`],
-  })),
+  projects: ['default', 'v0.14.0', 'v15.0.0', 'v16.0.0', 'v16.4.0', 'v16.13.0', 'v17.0.0'].map(
+    (version) => ({
+      displayName: version,
+      testMatch: [`<rootDir>/tests/${version}/*.spec.js`],
+    }),
+  ),
 };

--- a/src/index.js
+++ b/src/index.js
@@ -4,20 +4,23 @@
  * @returns {boolean} True if the argument appears to be a react synthetic event.
  *
  * Please refer to the implementation of each version.
+ * v0.14.0
  * @see https://github.com/facebook/react/blob/v0.14.0/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+ * v15.0.0
  * @see https://github.com/facebook/react/blob/v15.0.0/src/renderers/dom/client/syntheticEvents/SyntheticEvent.js
+ * v16.0.0
  * @see https://github.com/facebook/react/blob/v16.0.0/src/renderers/shared/shared/event/SyntheticEvent.js
+ * v16.4.0
  * @see https://github.com/facebook/react/blob/v16.4.0/packages/events/SyntheticEvent.js
+ * v16.13.0
  * @see https://github.com/facebook/react/blob/v16.13.0/packages/legacy-events/SyntheticEvent.js
+ * v17.0.0
+ * @see https://github.com/facebook/react/blob/v17.0.0/packages/react-dom/src/events/ReactSyntheticEventType.js#L25-L36
+ * @see https://github.com/facebook/react/blob/v17.0.0/packages/react-dom/src/events/SyntheticEvent.js#L26-L136
  */
 export default function isReactSyntheticEvent(event) {
   if (typeof event !== 'object' || event === null) {
     return false;
   }
-
-  const proto = Object.getPrototypeOf(event);
-  if ('_dispatchListeners' in event && proto && proto.constructor.Interface) {
-    return true;
-  }
-  return false;
+  return '_dispatchListeners' in event;
 }

--- a/tests/v17.0.0/index.spec.js
+++ b/tests/v17.0.0/index.spec.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import ReactTestUtils from 'react-dom/test-utils';
+
+import pkg from './package.json';
+import createExpect from '../create-expect';
+
+/**
+ * See https://github.com/facebook/react/blob/v17.0.0/packages/react-dom/src/events/ReactSyntheticEventType.js#L25-L36
+ * See https://github.com/facebook/react/blob/v17.0.0/packages/react-dom/src/events/SyntheticEvent.js#L26-L136
+ */
+describe(`${pkg.name} isReactSyntheticEvent`, () => {
+  const expectIsReactSyntheticEvent = createExpect(React, ReactDOM, ReactTestUtils);
+
+  it('should return true when argument is instance of react synthetic event', () => {
+    // Clipboard Event
+    expectIsReactSyntheticEvent('copy').toBe(true);
+    // Composition Events
+    expectIsReactSyntheticEvent('compositionEnd').toBe(true);
+    // Keyboard Event
+    expectIsReactSyntheticEvent('keyDown').toBe(true);
+    // Focus Event
+    expectIsReactSyntheticEvent('focus').toBe(true);
+    // Form Event
+    expectIsReactSyntheticEvent('change').toBe(true);
+    // Mouse Event
+    expectIsReactSyntheticEvent('click').toBe(true);
+    // Pointer Event
+    expectIsReactSyntheticEvent('pointerDown').toBe(true);
+    // Selection Event
+    expectIsReactSyntheticEvent('select').toBe(true);
+    // Touch Event
+    expectIsReactSyntheticEvent('touchCancel').toBe(true);
+    // UI Event
+    expectIsReactSyntheticEvent('scroll').toBe(true);
+    // Wheel Event
+    expectIsReactSyntheticEvent('wheel').toBe(true);
+    // Media Event
+    expectIsReactSyntheticEvent('abort').toBe(true);
+    // Image Event
+    expectIsReactSyntheticEvent('load').toBe(true);
+    // Animation Event
+    expectIsReactSyntheticEvent('animationStart').toBe(true);
+    // Transition Event
+    expectIsReactSyntheticEvent('transitionEnd').toBe(true);
+    // Other Event
+    expectIsReactSyntheticEvent('toggle').toBe(true);
+  });
+});

--- a/tests/v17.0.0/package-lock.json
+++ b/tests/v17.0.0/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "v17.0.0",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
+    },
+    "react": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-17.0.0.tgz",
+      "integrity": "sha512-rG9bqS3LMuetoSUKHN8G3fMNuQOePKDThK6+2yXFWtoeTDLVNh/QCaxT+Jr+rNf4lwNXpx+atdn3Aa0oi8/6eQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    },
+    "react-dom": {
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.0.tgz",
+      "integrity": "sha512-OGnFbxCjI2TMAZYMVxi4hqheJiN8rCEVVrL7XIGzCB6beNc4Am8M47HtkvxODZw9QgjmAPKpLba9FTu4fC1byA==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1",
+        "scheduler": "^0.20.0"
+      }
+    },
+    "scheduler": {
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.20.1.tgz",
+      "integrity": "sha512-LKTe+2xNJBNxu/QhHvDR14wUXHRQbVY5ZOYpOGWRzhydZUqrLb2JBvLPY7cAqFmqrWuDED0Mjk7013SZiOz6Bw==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0",
+        "object-assign": "^4.1.1"
+      }
+    }
+  }
+}

--- a/tests/v17.0.0/package.json
+++ b/tests/v17.0.0/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "v17.0.0",
+  "version": "1.0.0",
+  "private": true,
+  "author": "Taehwan Noh <taehwanno.dev@gmail.com>",
+  "license": "MIT",
+  "devDependencies": {
+    "react": "17.0.0",
+    "react-dom": "17.0.0"
+  }
+}


### PR DESCRIPTION
In React v17, the synthetic event object structure is changed. As you can see below link, the Interface of specific event is not referenced by constructor in the event's proto (`Object.getPrototypeOf` return value).

See: https://github.com/facebook/react/blob/v17.0.0/packages/react-dom/src/events/SyntheticEvent.js#L28

But when I look at `BaseSyntheticEvent` in `ReactSyntheticEventType`, some properties are still being used. is-react-synthetic-event's internal implementation was modified in consideration of backward compatibility.

See: https://github.com/facebook/react/blob/v17.0.0/packages/react-dom/src/events/ReactSyntheticEventType.js#L25-L36

**checklist**

- [ ] Implementation re-consideration (Looking at [the discussion](https://github.com/reactjs/rfcs/pull/112), SyntheticEvent can disappear and only browser native events are likely to be used in React. It is necessary to consider whether the current implementation is best. but when considering the purpose of this package, I think the current modified implementation is enough.)